### PR TITLE
Changes the eigvector extraction

### DIFF
--- a/apply_cgmm_beamforming.m
+++ b/apply_cgmm_beamforming.m
@@ -163,7 +163,7 @@ specs_enhan = zeros(num_frames, num_bins);
 
 for f = 1: num_bins
     % using Rx to estimate steer vector
-    [vector, value] = eig(R_x(:, :, f));
+    [vector, ~, ~] = svd(R_x(:, :, f));
     steer_vector = vector(:, 1);
     
     if rcond(R_n(:, :, f)) < theta


### PR DESCRIPTION
In Matlab, eig() function does not always return eigenvalues in sorted order, so we should sort it as https://www.mathworks.com/help/matlab/ref/eig.html “Sorted Eigenvalues and Eigenvectors” part do, or we can just use svd() function, which always returns eigenvalues in descending order(as https://www.mathworks.com/help/matlab/ref/double.svd.html  says) and then do the subsequent procedures.